### PR TITLE
Spi handle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ add_avr_executable("${PROJECT_NAME}"
   src/hardware/hw_serial.c
   src/hardware/rotary_encoder.c
   src/hardware/segment_display.c
+  src/hardware/shift_register.c
   src/hardware/spi.c
   src/hardware/sw_serial.c
   src/hardware/timer0.c

--- a/src/hardware/shift_register.c
+++ b/src/hardware/shift_register.c
@@ -23,3 +23,12 @@ void shift_register_read(const shift_register_t* shift_reg, bool* out_buf, uint8
 		out_buf[i] = (byte >> i % 8) & 1;
 	}
 }
+
+// Write bytes to 74HC595
+void shift_register_write(const shift_register_t* shift_reg, uint8_t* bytes, uint8_t num_bytes) {
+	for (uint8_t i = 0; i < num_bytes; i++) {
+		spi_send(shift_reg->spi, bytes[i]);
+	}
+	gpio_pin_clear(shift_reg->latch_pin);
+	gpio_pin_set(shift_reg->latch_pin);
+}

--- a/src/hardware/shift_register.c
+++ b/src/hardware/shift_register.c
@@ -8,6 +8,7 @@ shift_register_t shift_register_init(spi_t spi, gpio_pin_t latch_pin) {
 	};
 }
 
+// Read bits from 74HC165
 void shift_register_read(const shift_register_t* shift_reg, bool* out_buf, uint8_t out_buf_len) {
 	// Update shift register content
 	gpio_pin_clear(shift_reg->latch_pin);

--- a/src/hardware/shift_register.c
+++ b/src/hardware/shift_register.c
@@ -1,0 +1,24 @@
+#include "hardware/shift_register.h"
+
+shift_register_t shift_register_init(spi_t spi, gpio_pin_t latch_pin) {
+	gpio_pin_configure(latch_pin, PIN_MODE_OUTPUT);
+	return (shift_register_t) {
+		.spi = spi,
+		.latch_pin = latch_pin
+	};
+}
+
+void shift_register_read(const shift_register_t* shift_reg, bool* out_buf, uint8_t out_buf_len) {
+	// Update shift register content
+	gpio_pin_clear(shift_reg->latch_pin);
+	gpio_pin_set(shift_reg->latch_pin);
+
+	// Read content
+	uint8_t byte = 0;
+	for (uint8_t i = 0; i < out_buf_len; i++) {
+		if (i % 8 == 0) {
+			byte = spi_receive(shift_reg->spi);
+		}
+		out_buf[i] = (byte >> i % 8) & 1;
+	}
+}

--- a/src/hardware/shift_register.h
+++ b/src/hardware/shift_register.h
@@ -1,0 +1,17 @@
+#ifndef SHIFT_REGISTER_H
+#define SHIFT_REGISTER_H
+
+#include "hardware/spi.h"
+#include "hardware/gpio.h"
+
+#include <stdbool.h>
+
+typedef struct {
+	spi_t spi;
+	gpio_pin_t latch_pin;
+} shift_register_t;
+
+shift_register_t shift_register_init(spi_t spi, gpio_pin_t latch_pin);
+void shift_register_read(const shift_register_t* shift_reg, bool* out_buf, uint8_t out_buf_len);
+
+#endif /* SHIFT_REGISTER_H */

--- a/src/hardware/shift_register.h
+++ b/src/hardware/shift_register.h
@@ -5,6 +5,7 @@
 #include "hardware/gpio.h"
 
 #include <stdbool.h>
+#include <stdint.h>
 
 typedef struct {
 	spi_t spi;
@@ -13,5 +14,6 @@ typedef struct {
 
 shift_register_t shift_register_init(spi_t spi, gpio_pin_t latch_pin);
 void shift_register_read(const shift_register_t* shift_reg, bool* out_buf, uint8_t out_buf_len);
+void shift_register_write(const shift_register_t* shift_reg, uint8_t* bytes, uint8_t num_bytes);
 
 #endif /* SHIFT_REGISTER_H */

--- a/src/hardware/shift_register.h
+++ b/src/hardware/shift_register.h
@@ -1,8 +1,8 @@
 #ifndef SHIFT_REGISTER_H
 #define SHIFT_REGISTER_H
 
-#include "hardware/spi.h"
 #include "hardware/gpio.h"
+#include "hardware/spi.h"
 
 #include <stdbool.h>
 #include <stdint.h>

--- a/src/hardware/spi.c
+++ b/src/hardware/spi.c
@@ -4,7 +4,7 @@
 
 #include <avr/io.h>
 
-void spi_initialize(spi_data_order_t data_order) {
+spi_t spi_initialize(spi_data_order_t data_order) {
 	/* Configure pins */
 	set_bit(DDRB, 3); // Set MOSI pin to output
 	clear_bit(DDRB, 4); // Set MISO pin to input
@@ -15,15 +15,17 @@ void spi_initialize(spi_data_order_t data_order) {
 	set_bit(SPCR, MSTR); // Master mode
 	write_bit(SPCR, DORD, data_order); // Select order bits are sent
 	set_bit(SPCR, SPE); // SPI Enable (must be last!)
+
+	return (spi_t) {};
 }
 
-uint8_t spi_send(uint8_t byte) {
+uint8_t spi_send(spi_t spi, uint8_t byte) {
 	SPDR = byte; // start transmission
 	while (!(SPSR & (1 << SPIF))) { // wait for transmission to completele
 	}
 	return SPDR;
 }
 
-uint8_t spi_receive(void) {
-	return spi_send(0);
+uint8_t spi_receive(spi_t spi) {
+	return spi_send(spi, 0);
 }

--- a/src/hardware/spi.h
+++ b/src/hardware/spi.h
@@ -8,8 +8,12 @@ typedef enum {
 	SPI_DATA_ORDER_LSB_FIRST = 1,
 } spi_data_order_t;
 
-void spi_initialize(spi_data_order_t data_order);
-uint8_t spi_send(uint8_t byte);
-uint8_t spi_receive(void);
+typedef struct {
+	int: 0;
+} spi_t;
+
+spi_t spi_initialize(spi_data_order_t data_order);
+uint8_t spi_send(spi_t spi, uint8_t byte);
+uint8_t spi_receive(spi_t spi);
 
 #endif /* SPI_H */

--- a/src/main.c
+++ b/src/main.c
@@ -46,7 +46,7 @@ static void globally_enable_interrupts(void) {
 }
 
 // read bits from 74HC165
-static void read_shift_register_input(spi_t spi, gpio_pin_t latch_pin, bool* out_buf, uint8_t out_buf_len) {
+static void read_shift_register_input(gpio_pin_t latch_pin, spi_t spi, bool* out_buf, uint8_t out_buf_len) {
 	// Update shift register content
 	gpio_pin_clear(latch_pin);
 	gpio_pin_set(latch_pin);
@@ -70,9 +70,9 @@ static void write_shift_register_output(spi_t spi, gpio_pin_t latch_pin, uint8_t
 	gpio_pin_set(latch_pin);
 }
 
-static void update_button_states(spi_t spi, button_t* buttons, uint8_t num_buttons, gpio_pin_t latch_pin) {
+static void update_button_states(button_t* buttons, uint8_t num_buttons, gpio_pin_t latch_pin, spi_t spi) {
 	bool button_states[256];
-	read_shift_register_input(spi, latch_pin, button_states, num_buttons);
+	read_shift_register_input(latch_pin, spi, button_states, num_buttons);
 	for (uint8_t i = 0; i < num_buttons; i++) {
 		button_update(&buttons[i], button_states[i], timer0_now_ms());
 	}
@@ -116,7 +116,7 @@ int main(void) {
 	LOG_INFO("Program Start\n");
 	while (true) {
 		/* Read input */
-		update_button_states(spi, ui_devices.step_buttons, 8, step_buttons_latch_pin);
+		update_button_states(ui_devices.step_buttons, 8, step_buttons_latch_pin, spi);
 		button_update(&ui_devices.start_button, gpio_pin_read(start_button_pin), timer0_now_ms());
 		segment_display_update(&ui_devices.display); // cycle to next digit
 

--- a/src/main.c
+++ b/src/main.c
@@ -24,15 +24,6 @@
 #define DEFAULT_BPM 120
 #define QUARTERNOTE_PULSE_LENGTH_US 500
 
-// Write bytes to 74HC595
-void shift_register_write(const shift_register_t* shift_reg, uint8_t* bytes, uint8_t num_bytes) {
-	for (uint8_t i = 0; i < num_bytes; i++) {
-		spi_send(shift_reg->spi, bytes[i]);
-	}
-	gpio_pin_clear(shift_reg->latch_pin);
-	gpio_pin_set(shift_reg->latch_pin);
-}
-
 /* ----------------------- Interrupt service routines ----------------------- */
 ISR(TIMER0_OVF_vect) {
 	timer0_timer_overflow_irq();


### PR DESCRIPTION
Add a handle struct to SPI to track what functions depend on the SPI peripheral.
Add a shift register struct to make it easier to track SPI handle for functions using shift registers.