### PR TITLE
Rename state data to match Erlang FSM style

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -77,8 +77,8 @@ static void globally_enable_interrupts(void) {
 	sei();
 }
 
-static UserInterfaceInput read_ui_input(InterfaceDevices* interface_devices) {
-	return (UserInterfaceInput) {
+static UserInterfaceEvents get_ui_events(InterfaceDevices* interface_devices) {
+	return (UserInterfaceEvents) {
 		.rotary_encoder_diff = RotaryEncoder_read(&interface_devices->rotary_encoder),
 	};
 }
@@ -86,9 +86,9 @@ static UserInterfaceInput read_ui_input(InterfaceDevices* interface_devices) {
 #define MICROSECONDS_PER_SECOND 1e6
 #define BPM_PER_HZ 60
 
-static void set_playback_tempo(BeatClock* beat_clock, Timer1 timer1, uint16_t new_tempo_deci_bpm) {
-	beat_clock->tempo_deci_bpm = new_tempo_deci_bpm;
-	const uint32_t usec_per_pulse = MICROSECONDS_PER_SECOND * BPM_PER_HZ / ((BEAT_CLOCK_SEQUENCER_PPQN * (new_tempo_deci_bpm / 10)));
+static void set_playback_tempo(BeatClock* beat_clock, Timer1 timer1, uint16_t set_new_tempo_deci_bpm) {
+	beat_clock->tempo_deci_bpm = set_new_tempo_deci_bpm;
+	const uint32_t usec_per_pulse = MICROSECONDS_PER_SECOND * BPM_PER_HZ / ((BEAT_CLOCK_SEQUENCER_PPQN * (set_new_tempo_deci_bpm / 10)));
 	const uint16_t ticks_per_pulse = usec_per_pulse / TIMER1_USEC_PER_TICK;
 	Timer1_set_period(timer1, ticks_per_pulse);
 }
@@ -118,20 +118,20 @@ static uint8_t maybe_read_midi_byte(SoftwareSerial sw_serial) {
 	return byte;
 }
 
-static void handle_ui_events(Timer1 timer1, StepSequencer* step_sequencer, const UserInterfaceEvents* ui_events) {
-	if (ui_events->new_tempo_deci_bpm) {
-		set_playback_tempo(&step_sequencer->beat_clock, timer1, ui_events->new_tempo_deci_bpm);
+static void run_ui_commands(Timer1 timer1, StepSequencer* step_sequencer, const UserInterfaceCommands* commands) {
+	if (commands->set_new_tempo_deci_bpm) {
+		set_playback_tempo(&step_sequencer->beat_clock, timer1, commands->set_new_tempo_deci_bpm);
 	}
-	if (ui_events->start_playback) {
+	if (commands->start_playback) {
 		start_playback(&step_sequencer->beat_clock, timer1);
 	}
-	if (ui_events->stop_playback) {
+	if (commands->stop_playback) {
 		stop_playback(&step_sequencer->beat_clock, timer1);
 	}
 }
 
-static void handle_midi_control_events(Timer1 timer1, StepSequencer* step_sequencer, const MidiControlEvents* midi_events) {
-	if (midi_events->switch_to_external_clock) {
+static void run_midi_control_commands(Timer1 timer1, StepSequencer* step_sequencer, const MidiControlCommands* commands) {
+	if (commands->switch_to_external_clock) {
 		if (step_sequencer->beat_clock.source == BEAT_CLOCK_SOURCE_INTERNAL) {
 			LOG_INFO("Switched to external beat clock\n");
 			step_sequencer->beat_clock.source = BEAT_CLOCK_SOURCE_EXTERNAL;
@@ -139,7 +139,7 @@ static void handle_midi_control_events(Timer1 timer1, StepSequencer* step_sequen
 		}
 	}
 
-	if (midi_events->switch_to_internal_clock) {
+	if (commands->switch_to_internal_clock) {
 		if (step_sequencer->beat_clock.source == BEAT_CLOCK_SOURCE_EXTERNAL) {
 			LOG_INFO("Switched to internal beat clock\n");
 			step_sequencer->beat_clock.source = BEAT_CLOCK_SOURCE_INTERNAL;
@@ -240,14 +240,14 @@ int main(void) {
 	start_playback(&step_sequencer.beat_clock, timer1); // HACK, start playback immediately
 	while (true) {
 		/* User Interface */
-		const UserInterfaceInput ui_input = read_ui_input(&interface_devices);
-		const UserInterfaceEvents ui_events = UserInterface_update(&user_interface, &ui_input, &step_sequencer);
-		handle_ui_events(timer1, &step_sequencer, &ui_events);
+		const UserInterfaceEvents ui_events = get_ui_events(&interface_devices);
+		const UserInterfaceCommands ui_cmds = UserInterface_update(&user_interface, &ui_events, &step_sequencer);
+		run_ui_commands(timer1, &step_sequencer, &ui_cmds);
 
 		/* MIDI Control */
 		const uint8_t midi_byte = maybe_read_midi_byte(sw_serial);
-		const MidiControlEvents midi_events = MidiControl_update(&midi_control, midi_byte);
-		handle_midi_control_events(timer1, &step_sequencer, &midi_events);
+		const MidiControlCommands midi_cmds = MidiControl_update(&midi_control, midi_byte);
+		run_midi_control_commands(timer1, &step_sequencer, &midi_cmds);
 
 		/* Interface Devices */
 		update_segment_display(&interface_devices.segment_display, &user_interface);

--- a/src/sequencer/midi_control.c
+++ b/src/sequencer/midi_control.c
@@ -6,17 +6,17 @@ MidiControl MidiControl_init(Timer0 timer0) {
 	};
 }
 
-MidiControlEvents MidiControl_update(MidiControl* midi_control, uint8_t midi_byte) {
-	MidiControlEvents events = { 0 };
+MidiControlCommands MidiControl_update(MidiControl* midi_control, uint8_t midi_byte) {
+	MidiControlCommands commands = { 0 };
 
 	if (midi_byte == MIDI_TIMING_CLOCK) {
-		events.switch_to_external_clock = true;
+		commands.switch_to_external_clock = true;
 		MillisecondTimer_reset(&midi_control->midi_clock_timeout_timer);
 	}
 
 	if (MillisecondTimer_elapsed(&midi_control->midi_clock_timeout_timer)) {
-		events.switch_to_internal_clock = true;
+		commands.switch_to_internal_clock = true;
 	}
 
-	return events;
+	return commands;
 }

--- a/src/sequencer/midi_control.h
+++ b/src/sequencer/midi_control.h
@@ -12,13 +12,13 @@
 typedef struct {
 	bool switch_to_internal_clock;
 	bool switch_to_external_clock;
-} MidiControlEvents;
+} MidiControlCommands;
 
 typedef struct {
 	MillisecondTimer midi_clock_timeout_timer;
 } MidiControl;
 
 MidiControl MidiControl_init(Timer0 timer0);
-MidiControlEvents MidiControl_update(MidiControl* midi_control, uint8_t midi_byte);
+MidiControlCommands MidiControl_update(MidiControl* midi_control, uint8_t midi_byte);
 
 #endif /* MIDI_CONTROL_H */

--- a/src/user_interface/user_interface.c
+++ b/src/user_interface/user_interface.c
@@ -8,13 +8,13 @@ UserInterface UserInterface_init(void) {
 	return (UserInterface) { 0 };
 }
 
-UserInterfaceEvents UserInterface_update(UserInterface* ui, const UserInterfaceInput* input, const StepSequencer* step_sequencer) {
-	UserInterfaceEvents events = { 0 };
+UserInterfaceCommands UserInterface_update(UserInterface* ui, const UserInterfaceEvents* events, const StepSequencer* step_sequencer) {
+	UserInterfaceCommands commands = { 0 };
 	const BeatClockSource clock_source = step_sequencer->beat_clock.source;
 
 	/* Set Tempo */
 	if (clock_source == BEAT_CLOCK_SOURCE_INTERNAL) {
-		events.new_tempo_deci_bpm = clamp(step_sequencer->beat_clock.tempo_deci_bpm + 10 * input->rotary_encoder_diff, MIN_TEMPO, MAX_TEMPO);
+		commands.set_new_tempo_deci_bpm = clamp(step_sequencer->beat_clock.tempo_deci_bpm + 10 * events->rotary_encoder_diff, MIN_TEMPO, MAX_TEMPO);
 	}
 
 	/* Tempo display */
@@ -38,5 +38,5 @@ UserInterfaceEvents UserInterface_update(UserInterface* ui, const UserInterfaceI
 		} break;
 	}
 
-	return events;
+	return commands;
 }

--- a/src/user_interface/user_interface.h
+++ b/src/user_interface/user_interface.h
@@ -13,15 +13,15 @@ typedef struct {
 
 typedef struct {
 	int8_t rotary_encoder_diff;
-} UserInterfaceInput;
+} UserInterfaceEvents;
 
 typedef struct {
 	bool start_playback;
 	bool stop_playback;
-	uint16_t new_tempo_deci_bpm;
-} UserInterfaceEvents;
+	uint16_t set_new_tempo_deci_bpm;
+} UserInterfaceCommands;
 
 UserInterface UserInterface_init(void);
-UserInterfaceEvents UserInterface_update(UserInterface* ui, const UserInterfaceInput* input, const StepSequencer* step_sequencer);
+UserInterfaceCommands UserInterface_update(UserInterface* ui, const UserInterfaceEvents* events, const StepSequencer* step_sequencer);
 
 #endif /* PLAYBACK_CONTROL_H */

--- a/tests/midi_control_tests.c
+++ b/tests/midi_control_tests.c
@@ -12,23 +12,23 @@ Timer0 MockTimer0_init() {
 	return (Timer0) { .dummy = 0 };
 }
 
-TEST(MidiControl, empty_input_gives_no_events) {
+TEST(MidiControl, empty_input_gives_no_commands) {
 	const Timer0 timer0 = MockTimer0_init();
 	MidiControl midi_control = MidiControl_init(timer0);
 
-	const MidiControlCommands events = MidiControl_update(&midi_control, MIDI_NO_MSG);
+	const MidiControlCommands commands = MidiControl_update(&midi_control, MIDI_NO_MSG);
 
 	const MidiControlCommands expected = { 0 };
-	EXPECT_MIDI_CONTROL_EVENTS_EQ(events, expected);
+	EXPECT_MIDI_CONTROL_EVENTS_EQ(commands, expected);
 }
 
 TEST(MidiControl, when_receiving_a_midi_clock_byte_then_switches_to_external_clock) {
 	const Timer0 timer0 = MockTimer0_init();
 	MidiControl midi_control = MidiControl_init(timer0);
 
-	const MidiControlCommands events = MidiControl_update(&midi_control, MIDI_TIMING_CLOCK);
+	const MidiControlCommands commands = MidiControl_update(&midi_control, MIDI_TIMING_CLOCK);
 
-	EXPECT_TRUE(events.switch_to_external_clock);
+	EXPECT_TRUE(commands.switch_to_external_clock);
 }
 
 TEST(MidiControl, if_no_midi_clock_and_timeout_then_switch_to_internal_clock) {
@@ -41,9 +41,9 @@ TEST(MidiControl, if_no_midi_clock_and_timeout_then_switch_to_internal_clock) {
 
 	// no clock received after timeout elapsed
 	MockTime_set_now_ms(1234 + MIDI_CONTROL_CLOCK_TIMEOUT_MS);
-	const MidiControlCommands events = MidiControl_update(&midi_control, MIDI_NO_MSG);
+	const MidiControlCommands commands = MidiControl_update(&midi_control, MIDI_NO_MSG);
 
-	EXPECT_TRUE(events.switch_to_internal_clock);
+	EXPECT_TRUE(commands.switch_to_internal_clock);
 }
 
 TEST(MidiControl, if_no_midi_clock_and_no_timeout_then_does_not_switch_to_internal_clock) {
@@ -56,7 +56,7 @@ TEST(MidiControl, if_no_midi_clock_and_no_timeout_then_does_not_switch_to_intern
 
 	// no clock received, but timeout has not elapsed yet
 	MockTime_set_now_ms(1234 + MIDI_CONTROL_CLOCK_TIMEOUT_MS - 1);
-	const MidiControlCommands events = MidiControl_update(&midi_control, MIDI_NO_MSG);
+	const MidiControlCommands commands = MidiControl_update(&midi_control, MIDI_NO_MSG);
 
-	EXPECT_FALSE(events.switch_to_internal_clock);
+	EXPECT_FALSE(commands.switch_to_internal_clock);
 }

--- a/tests/midi_control_tests.c
+++ b/tests/midi_control_tests.c
@@ -16,9 +16,9 @@ TEST(MidiControl, empty_input_gives_no_events) {
 	const Timer0 timer0 = MockTimer0_init();
 	MidiControl midi_control = MidiControl_init(timer0);
 
-	const MidiControlEvents events = MidiControl_update(&midi_control, MIDI_NO_MSG);
+	const MidiControlCommands events = MidiControl_update(&midi_control, MIDI_NO_MSG);
 
-	const MidiControlEvents expected = { 0 };
+	const MidiControlCommands expected = { 0 };
 	EXPECT_MIDI_CONTROL_EVENTS_EQ(events, expected);
 }
 
@@ -26,7 +26,7 @@ TEST(MidiControl, when_receiving_a_midi_clock_byte_then_switches_to_external_clo
 	const Timer0 timer0 = MockTimer0_init();
 	MidiControl midi_control = MidiControl_init(timer0);
 
-	const MidiControlEvents events = MidiControl_update(&midi_control, MIDI_TIMING_CLOCK);
+	const MidiControlCommands events = MidiControl_update(&midi_control, MIDI_TIMING_CLOCK);
 
 	EXPECT_TRUE(events.switch_to_external_clock);
 }
@@ -41,7 +41,7 @@ TEST(MidiControl, if_no_midi_clock_and_timeout_then_switch_to_internal_clock) {
 
 	// no clock received after timeout elapsed
 	MockTime_set_now_ms(1234 + MIDI_CONTROL_CLOCK_TIMEOUT_MS);
-	const MidiControlEvents events = MidiControl_update(&midi_control, MIDI_NO_MSG);
+	const MidiControlCommands events = MidiControl_update(&midi_control, MIDI_NO_MSG);
 
 	EXPECT_TRUE(events.switch_to_internal_clock);
 }
@@ -56,7 +56,7 @@ TEST(MidiControl, if_no_midi_clock_and_no_timeout_then_does_not_switch_to_intern
 
 	// no clock received, but timeout has not elapsed yet
 	MockTime_set_now_ms(1234 + MIDI_CONTROL_CLOCK_TIMEOUT_MS - 1);
-	const MidiControlEvents events = MidiControl_update(&midi_control, MIDI_NO_MSG);
+	const MidiControlCommands events = MidiControl_update(&midi_control, MIDI_NO_MSG);
 
 	EXPECT_FALSE(events.switch_to_internal_clock);
 }

--- a/tests/user_interface_tests.c
+++ b/tests/user_interface_tests.c
@@ -15,17 +15,17 @@
 	}
 
 TEST(UserInterface, shows_dashes_on_display_when_beat_clock_source_is_external) {
-	const UserInterfaceEvents input = { 0 };
+	const UserInterfaceEvents events = { 0 };
 	UserInterface user_interface = UserInterface_init();
 	StepSequencer step_sequencer = StepSequencer_init();
 
 	// should show BPM
 	step_sequencer.beat_clock.source = BEAT_CLOCK_SOURCE_INTERNAL;
-	UserInterface_update(&user_interface, &input, &step_sequencer);
+	UserInterface_update(&user_interface, &events, &step_sequencer);
 
 	// should now switch to just dashes
 	step_sequencer.beat_clock.source = BEAT_CLOCK_SOURCE_EXTERNAL;
-	UserInterface_update(&user_interface, &input, &step_sequencer);
+	UserInterface_update(&user_interface, &events, &step_sequencer);
 
 	const char expected_chars[5] = "----";
 	const bool expected_periods[4] = { false, false, false, false };
@@ -34,14 +34,14 @@ TEST(UserInterface, shows_dashes_on_display_when_beat_clock_source_is_external) 
 }
 
 TEST(UserInterface, shows_bpm_on_display_when_beat_clock_source_is_internal) {
-	const UserInterfaceEvents input = { 0 };
+	const UserInterfaceEvents events = { 0 };
 	UserInterface user_interface = UserInterface_init();
 	StepSequencer step_sequencer = StepSequencer_init();
 
 	// set BPM to 120.3
 	step_sequencer.beat_clock.source = BEAT_CLOCK_SOURCE_INTERNAL;
 	step_sequencer.beat_clock.tempo_deci_bpm = 1203;
-	UserInterface_update(&user_interface, &input, &step_sequencer);
+	UserInterface_update(&user_interface, &events, &step_sequencer);
 
 	const char expected_chars[5] = "1203";
 	const bool expected_periods[4] = { false, false, true, false };
@@ -50,25 +50,25 @@ TEST(UserInterface, shows_bpm_on_display_when_beat_clock_source_is_internal) {
 }
 
 TEST(UserInterface, rotary_encoder_changes_tempo_when_clock_source_is_internal) {
-	const UserInterfaceEvents input = { .rotary_encoder_diff = 1 };
+	const UserInterfaceEvents events = { .rotary_encoder_diff = 1 };
 	UserInterface user_interface = UserInterface_init();
 	StepSequencer step_sequencer = StepSequencer_init();
 
 	step_sequencer.beat_clock.source = BEAT_CLOCK_SOURCE_INTERNAL;
 	step_sequencer.beat_clock.tempo_deci_bpm = 1200;
-	UserInterfaceCommands commands = UserInterface_update(&user_interface, &input, &step_sequencer);
+	UserInterfaceCommands commands = UserInterface_update(&user_interface, &events, &step_sequencer);
 
 	EXPECT_EQ(commands.set_new_tempo_deci_bpm, 1210);
 }
 
 TEST(UserInterface, rotary_encoder_does_not_change_tempo_when_clock_source_is_external) {
-	const UserInterfaceEvents input = { .rotary_encoder_diff = 1 };
+	const UserInterfaceEvents events = { .rotary_encoder_diff = 1 };
 	UserInterface user_interface = UserInterface_init();
 	StepSequencer step_sequencer = StepSequencer_init();
 
 	step_sequencer.beat_clock.source = BEAT_CLOCK_SOURCE_EXTERNAL;
 	step_sequencer.beat_clock.tempo_deci_bpm = 1200;
-	UserInterfaceCommands commands = UserInterface_update(&user_interface, &input, &step_sequencer);
+	UserInterfaceCommands commands = UserInterface_update(&user_interface, &events, &step_sequencer);
 
 	EXPECT_EQ(commands.set_new_tempo_deci_bpm, 0);
 }

--- a/tests/user_interface_tests.c
+++ b/tests/user_interface_tests.c
@@ -15,7 +15,7 @@
 	}
 
 TEST(UserInterface, shows_dashes_on_display_when_beat_clock_source_is_external) {
-	const UserInterfaceInput input = { 0 };
+	const UserInterfaceEvents input = { 0 };
 	UserInterface user_interface = UserInterface_init();
 	StepSequencer step_sequencer = StepSequencer_init();
 
@@ -34,7 +34,7 @@ TEST(UserInterface, shows_dashes_on_display_when_beat_clock_source_is_external) 
 }
 
 TEST(UserInterface, shows_bpm_on_display_when_beat_clock_source_is_internal) {
-	const UserInterfaceInput input = { 0 };
+	const UserInterfaceEvents input = { 0 };
 	UserInterface user_interface = UserInterface_init();
 	StepSequencer step_sequencer = StepSequencer_init();
 
@@ -50,25 +50,25 @@ TEST(UserInterface, shows_bpm_on_display_when_beat_clock_source_is_internal) {
 }
 
 TEST(UserInterface, rotary_encoder_changes_tempo_when_clock_source_is_internal) {
-	const UserInterfaceInput input = { .rotary_encoder_diff = 1 };
+	const UserInterfaceEvents input = { .rotary_encoder_diff = 1 };
 	UserInterface user_interface = UserInterface_init();
 	StepSequencer step_sequencer = StepSequencer_init();
 
 	step_sequencer.beat_clock.source = BEAT_CLOCK_SOURCE_INTERNAL;
 	step_sequencer.beat_clock.tempo_deci_bpm = 1200;
-	UserInterfaceEvents events = UserInterface_update(&user_interface, &input, &step_sequencer);
+	UserInterfaceCommands events = UserInterface_update(&user_interface, &input, &step_sequencer);
 
-	EXPECT_EQ(events.new_tempo_deci_bpm, 1210);
+	EXPECT_EQ(events.set_new_tempo_deci_bpm, 1210);
 }
 
 TEST(UserInterface, rotary_encoder_does_not_change_tempo_when_clock_source_is_external) {
-	const UserInterfaceInput input = { .rotary_encoder_diff = 1 };
+	const UserInterfaceEvents input = { .rotary_encoder_diff = 1 };
 	UserInterface user_interface = UserInterface_init();
 	StepSequencer step_sequencer = StepSequencer_init();
 
 	step_sequencer.beat_clock.source = BEAT_CLOCK_SOURCE_EXTERNAL;
 	step_sequencer.beat_clock.tempo_deci_bpm = 1200;
-	UserInterfaceEvents events = UserInterface_update(&user_interface, &input, &step_sequencer);
+	UserInterfaceCommands events = UserInterface_update(&user_interface, &input, &step_sequencer);
 
-	EXPECT_EQ(events.new_tempo_deci_bpm, 0);
+	EXPECT_EQ(events.set_new_tempo_deci_bpm, 0);
 }

--- a/tests/user_interface_tests.c
+++ b/tests/user_interface_tests.c
@@ -56,9 +56,9 @@ TEST(UserInterface, rotary_encoder_changes_tempo_when_clock_source_is_internal) 
 
 	step_sequencer.beat_clock.source = BEAT_CLOCK_SOURCE_INTERNAL;
 	step_sequencer.beat_clock.tempo_deci_bpm = 1200;
-	UserInterfaceCommands events = UserInterface_update(&user_interface, &input, &step_sequencer);
+	UserInterfaceCommands commands = UserInterface_update(&user_interface, &input, &step_sequencer);
 
-	EXPECT_EQ(events.set_new_tempo_deci_bpm, 1210);
+	EXPECT_EQ(commands.set_new_tempo_deci_bpm, 1210);
 }
 
 TEST(UserInterface, rotary_encoder_does_not_change_tempo_when_clock_source_is_external) {
@@ -68,7 +68,7 @@ TEST(UserInterface, rotary_encoder_does_not_change_tempo_when_clock_source_is_ex
 
 	step_sequencer.beat_clock.source = BEAT_CLOCK_SOURCE_EXTERNAL;
 	step_sequencer.beat_clock.tempo_deci_bpm = 1200;
-	UserInterfaceCommands events = UserInterface_update(&user_interface, &input, &step_sequencer);
+	UserInterfaceCommands commands = UserInterface_update(&user_interface, &input, &step_sequencer);
 
-	EXPECT_EQ(events.set_new_tempo_deci_bpm, 0);
+	EXPECT_EQ(commands.set_new_tempo_deci_bpm, 0);
 }


### PR DESCRIPTION
Erlang uses the following schema for state machines:

```
State(S) x Event(E) -> Actions(A), State(S')
```

Rename the input types to use `Event` suffix, and the output types to use the `Command` suffix.